### PR TITLE
Fix typo

### DIFF
--- a/eng-fra/eng-fra.tei
+++ b/eng-fra/eng-fra.tei
@@ -92143,7 +92143,7 @@
                   <quote>démissioner</quote>
                </cit>
                <cit type="trans">
-                  <quote>re retirer</quote>
+                  <quote>retirer</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -95615,7 +95615,7 @@
                   <quote>démissioner</quote>
                </cit>
                <cit type="trans">
-                  <quote>re retirer</quote>
+                  <quote>retirer</quote>
                </cit>
             </sense>
             <sense n="3">


### PR DESCRIPTION
There seems to have a typo in the translations where the French word "retirer" was written "re retirer".