### PR TITLE
More spanish fixes

### DIFF
--- a/eng-spa/eng-spa.tei
+++ b/eng-spa/eng-spa.tei
@@ -5061,7 +5061,7 @@
                   <quote>a</quote>
                </cit>
                <cit type="trans">
-                  <quote>dentrode</quote>
+                  <quote>dentro de</quote>
                </cit>
                <cit type="trans">
                   <quote>en</quote>
@@ -5609,18 +5609,18 @@
                   <quote>porlotocantea</quote>
                </cit>
                <cit type="trans">
-                  <quote>respectode</quote>
+                  <quote>respecto de</quote>
                </cit>
             </sense>
             <sense>
                <cit type="trans">
-                  <quote>aesode</quote>
+                  <quote>a eso de</quote>
                </cit>
                <cit type="trans">
                   <quote>apróximadamente</quote>
                </cit>
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
             <sense>
@@ -5628,7 +5628,7 @@
                   <quote>alrededorde</quote>
                </cit>
                <cit type="trans">
-                  <quote>entornode</quote>
+                  <quote>en torno de</quote>
                </cit>
             </sense>
          </entry>
@@ -5652,12 +5652,12 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>alnortede</quote>
+                  <quote>al norte de</quote>
                </cit>
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>encimade</quote>
+                  <quote>encima de</quote>
                </cit>
             </sense>
             <sense n="3">
@@ -5884,10 +5884,10 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>deveras</quote>
+                  <quote>de veras</quote>
                </cit>
                <cit type="trans">
-                  <quote>enrealidad</quote>
+                  <quote>en realidad</quote>
                </cit>
                <cit type="trans">
                   <quote>verdaderamente</quote>
@@ -7498,7 +7498,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>serpartidariode</quote>
+                  <quote>ser partidario de</quote>
                </cit>
             </sense>
          </entry>
@@ -8553,10 +8553,10 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>denuevo</quote>
+                  <quote>de nuevo</quote>
                </cit>
                <cit type="trans">
-                  <quote>otravez</quote>
+                  <quote>otra vez</quote>
                </cit>
             </sense>
             </entry>
@@ -8567,7 +8567,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>detrásde</quote>
+                  <quote>detrás de</quote>
                </cit>
                <cit type="trans">
                   <quote>tras</quote>
@@ -8603,7 +8603,7 @@
                   <quote>luego</quote>
                </cit>
                <cit type="trans">
-                  <quote>másadelante</quote>
+                  <quote>más adelante</quote>
                </cit>
             </sense>
          </entry>
@@ -8614,10 +8614,10 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>denuevo</quote>
+                  <quote>de nuevo</quote>
                </cit>
                <cit type="trans">
-                  <quote>otravez</quote>
+                  <quote>otra vez</quote>
                </cit>
             </sense>
             </entry>
@@ -9467,7 +9467,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>todaclasede</quote>
+                  <quote>toda clase de</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -9526,13 +9526,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>degolpe</quote>
+                  <quote>de golpe</quote>
                </cit>
                <cit type="trans">
-                  <quote>derepente</quote>
+                  <quote>de repente</quote>
                </cit>
                <cit type="trans">
-                  <quote>desopetón</quote>
+                  <quote>de sopetón</quote>
                </cit>
             </sense>
          </entry>
@@ -9543,10 +9543,10 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>denuevo</quote>
+                  <quote>de nuevo</quote>
                </cit>
                <cit type="trans">
-                  <quote>otravez</quote>
+                  <quote>otra vez</quote>
                </cit>
             </sense>
          </entry>
@@ -9557,7 +9557,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>todaclasede</quote>
+                  <quote>toda clase de</quote>
                </cit>
             </sense>
          </entry>
@@ -9568,7 +9568,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>todaclasede</quote>
+                  <quote>toda clase de</quote>
                </cit>
             </sense>
          </entry>
@@ -9582,7 +9582,7 @@
                   <quote>cada</quote>
                </cit>
                <cit type="trans">
-                  <quote>cadauno</quote>
+                  <quote>cada uno</quote>
                </cit>
                <cit type="trans">
                   <quote>todo</quote>
@@ -9646,7 +9646,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>pastadealmendras</quote>
+                  <quote>pasta de almendras</quote>
                </cit>
             </sense>
          </entry>
@@ -9668,7 +9668,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>pasteldealmendra</quote>
+                  <quote>pastel de almendra</quote>
                </cit>
             </sense>
          </entry>
@@ -9704,7 +9704,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>alolargode</quote>
+                  <quote>a lo largo de</quote>
                </cit>
             </sense>
          </entry>
@@ -10192,10 +10192,10 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>denuevo</quote>
+                  <quote>de nuevo</quote>
                </cit>
                <cit type="trans">
-                  <quote>otravez</quote>
+                  <quote>otra vez</quote>
                </cit>
             </sense>
          </entry>
@@ -11146,13 +11146,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>aesode</quote>
+                  <quote>a eso de</quote>
                </cit>
                <cit type="trans">
                   <quote>apróximadamente</quote>
                </cit>
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
          </entry>
@@ -11469,7 +11469,7 @@
                   <quote>alrededorde</quote>
                </cit>
                <cit type="trans">
-                  <quote>entornode</quote>
+                  <quote>en torno de</quote>
                </cit>
             </sense>
          </entry>
@@ -11754,7 +11754,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>atítulode</quote>
+                  <quote>a título de</quote>
                </cit>
                <cit type="trans">
                   <quote>como</quote>
@@ -12201,7 +12201,7 @@
                   <quote>porlotocantea</quote>
                </cit>
                <cit type="trans">
-                  <quote>respectode</quote>
+                  <quote>respecto de</quote>
                </cit>
             </sense>
          </entry>
@@ -12229,7 +12229,7 @@
                   <quote>porlotocantea</quote>
                </cit>
                <cit type="trans">
-                  <quote>respectode</quote>
+                  <quote>respecto de</quote>
                </cit>
             </sense>
          </entry>
@@ -12264,7 +12264,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
          </entry>
@@ -13325,7 +13325,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>procedentede</quote>
+                  <quote>procedente de</quote>
                </cit>
             </sense>
          </entry>
@@ -13425,7 +13425,7 @@
                   <quote>bocaarriba</quote>
                </cit>
                <cit type="trans">
-                  <quote>deespaldas</quote>
+                  <quote>de espaldas</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -13433,7 +13433,7 @@
                   <quote>atrás</quote>
                </cit>
                <cit type="trans">
-                  <quote>haciaatrás</quote>
+                  <quote>hacia atrás</quote>
                </cit>
             </sense>
             <sense n="3">
@@ -13457,7 +13457,7 @@
                   <quote>atrás</quote>
                </cit>
                <cit type="trans">
-                  <quote>haciaatrás</quote>
+                  <quote>hacia atrás</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -13465,7 +13465,7 @@
                   <quote>bocaarriba</quote>
                </cit>
                <cit type="trans">
-                  <quote>deespaldas</quote>
+                  <quote>de espaldas</quote>
                </cit>
                </sense>
             </entry>
@@ -14949,7 +14949,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>conmotivode</quote>
+                  <quote>con motivo de</quote>
                </cit>
             </sense>
          </entry>
@@ -15155,12 +15155,12 @@
                   <quote>antes</quote>
                </cit>
                <cit type="trans">
-                  <quote>delantede</quote>
+                  <quote>delante de</quote>
                </cit>
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>antesdeque</quote>
+                  <quote>antes de que</quote>
                </cit>
             </sense>
          </entry>
@@ -15174,7 +15174,7 @@
                   <quote>mendigar</quote>
                </cit>
                <cit type="trans">
-                  <quote>pedirlimosna</quote>
+                  <quote>pedir limosna</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -15318,7 +15318,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>detrásde</quote>
+                  <quote>detrás de</quote>
                </cit>
                <cit type="trans">
                   <quote>tras</quote>
@@ -15436,7 +15436,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>debajode</quote>
+                  <quote>debajo de</quote>
                </cit>
             </sense>
             </entry>
@@ -15494,7 +15494,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>debajode</quote>
+                  <quote>debajo de</quote>
                </cit>
             </sense>
          </entry>
@@ -15568,7 +15568,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
          </entry>
@@ -15724,7 +15724,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>derivardelrumbo</quote>
+                  <quote>derivar del rumbo</quote>
                </cit>
             </sense>
          </entry>
@@ -18729,7 +18729,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -18742,7 +18742,7 @@
             </sense>
             <sense n="3">
                <cit type="trans">
-                  <quote>pormediode</quote>
+                  <quote>pormedio de</quote>
                </cit>
             </sense>
          </entry>
@@ -18778,7 +18778,7 @@
          </entry>
          <entry>
             <form>
-               <orth>by</orth>
+               <orth>by chance</orth>
                <pron>biːtʃɑːns</pron>
             </form>
             <sense>
@@ -18789,40 +18789,40 @@
          </entry>
          <entry>
             <form>
-               <orth>by</orth>
+               <orth>by day</orth>
                <pron>biːdei</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>dedia</quote>
+                  <quote>de día</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>by</orth>
+               <orth>by heart</orth>
                <pron>biːhɑːt</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>dememoria</quote>
+                  <quote>de memoria</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>by</orth>
+               <orth>by means of</orth>
                <pron>biːmiːnzɔf</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>pormediode</quote>
+                  <quote>por medio de</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>by</orth>
+               <orth>by now</orth>
                <pron>biːnau</pron>
             </form>
             <sense>
@@ -18833,26 +18833,26 @@
          </entry>
          <entry>
             <form>
-               <orth>by</orth>
+               <orth>by no means</orth>
                <pron>biːnoumiːnz</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deningunamanera</quote>
+                  <quote>de ninguna manera</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>by</orth>
+               <orth>by the way</orth>
                <pron>biːðwei</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>apropósito</quote>
+                  <quote>a propósito</quote>
                </cit>
                <cit type="trans">
-                  <quote>depaso</quote>
+                  <quote>de paso</quote>
                </cit>
             </sense>
          </entry>
@@ -18862,7 +18862,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>aparcamientodetaxis</quote>
+                  <quote>aparcamiento de taxis</quote>
                </cit>
             </sense>
          </entry>
@@ -19531,7 +19531,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>cuidarsede</quote>
+                  <quote>cuidarse de</quote>
                </cit>
             </sense>
          </entry>
@@ -22763,7 +22763,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>procedentede</quote>
+                  <quote>procedente de</quote>
                </cit>
             </sense>
          </entry>
@@ -23446,7 +23446,7 @@
                   <quote>porlotocantea</quote>
                </cit>
                <cit type="trans">
-                  <quote>respectode</quote>
+                  <quote>respecto de</quote>
                </cit>
             </sense>
          </entry>
@@ -26226,7 +26226,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>detodoslosdías</quote>
+                  <quote>de todos los días</quote>
                </cit>
                <cit type="trans">
                   <quote>diario</quote>
@@ -26381,12 +26381,12 @@
          </entry>
          <entry>
             <form>
-               <orth>danger</orth>
+               <orth>danger of skidding</orth>
                <pron>deindʒərɔfskidiŋ</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>carreteraresbaladiza</quote>
+                  <quote>carretera resbaladiza</quote>
                </cit>
             </sense>
          </entry>
@@ -26555,7 +26555,7 @@
          </entry>
          <entry>
             <form>
-               <orth>deal</orth>
+               <orth>deal with</orth>
                <pron>diːlwið</pron>
             </form>
             <sense>
@@ -26814,7 +26814,7 @@
          </entry>
          <entry>
             <form>
-               <orth>declaration</orth>
+               <orth>declaration of policy</orth>
                <pron>dekləreiʃənɔfpɔləsiː</pron>
             </form>
             <sense>
@@ -27030,12 +27030,12 @@
          </entry>
          <entry>
             <form>
-               <orth>definite</orth>
+               <orth>definite article</orth>
                <pron>definətɑːtikl</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>artículodeterminado</quote>
+                  <quote>artículo determinado</quote>
                </cit>
             </sense>
          </entry>
@@ -27052,7 +27052,7 @@
          </entry>
          <entry>
             <form>
-               <orth>defray</orth>
+               <orth>defray the cost of</orth>
                <pron>difreiðkɔstɔf</pron>
             </form>
             <sense>
@@ -27137,7 +27137,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>depropósito</quote>
+                  <quote>de propósito</quote>
                </cit>
             </sense>
          </entry>
@@ -27302,18 +27302,18 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>pronombredemonstrativo</quote>
+                  <quote>pronombre demonstrativo</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>demonstrative</orth>
+               <orth>demonstrative pronoun</orth>
                <pron>demənstrətivprounaun</pron>
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>pronombredemonstrativo</quote>
+                  <quote>pronombre demonstrativo</quote>
                </cit>
             </sense>
             </entry>
@@ -27427,12 +27427,12 @@
          </entry>
          <entry>
             <form>
-               <orth>depend</orth>
+               <orth>depend on</orth>
                <pron>dipendɔnldipendəpɔn</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>dependerde</quote>
+                  <quote>depender de</quote>
                </cit>
             </sense>
          </entry>
@@ -28088,7 +28088,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deotramanera</quote>
+                  <quote>de otra manera</quote>
                </cit>
             </sense>
          </entry>
@@ -29528,7 +29528,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>derivardelrumbo</quote>
+                  <quote>derivar del rumbo</quote>
                </cit>
             </sense>
          </entry>
@@ -29896,12 +29896,12 @@
          </entry>
          <entry>
             <form>
-               <orth>during</orth>
+               <orth>during day</orth>
                <pron>djeəriŋðdei</pron>
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>dedia</quote>
+                  <quote>de día</quote>
                </cit>
             </sense>
             </entry>
@@ -30011,7 +30011,7 @@
                   <quote>cada</quote>
                </cit>
                <cit type="trans">
-                  <quote>cadauno</quote>
+                  <quote>cada uno</quote>
                </cit>
                <cit type="trans">
                   <quote>todo</quote>
@@ -30649,7 +30649,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>deotramanera</quote>
+                  <quote>de otra manera</quote>
                </cit>
             </sense>
          </entry>
@@ -30795,7 +30795,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>hacerusode</quote>
+                  <quote>hacer uso de</quote>
                </cit>
                <cit type="trans">
                   <quote>usar</quote>
@@ -31722,7 +31722,7 @@
                   <quote>cada</quote>
                </cit>
                <cit type="trans">
-                  <quote>cadauno</quote>
+                  <quote>cada uno</quote>
                </cit>
                <cit type="trans">
                   <quote>todo</quote>
@@ -31739,7 +31739,7 @@
                   <quote>cada</quote>
                </cit>
                <cit type="trans">
-                  <quote>cadauno</quote>
+                  <quote>cada uno</quote>
                </cit>
                <cit type="trans">
                   <quote>todo</quote>
@@ -31775,7 +31775,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>todaclasede</quote>
+                  <quote>toda clase de</quote>
                </cit>
             </sense>
          </entry>
@@ -31789,7 +31789,7 @@
                   <quote>cada</quote>
                </cit>
                <cit type="trans">
-                  <quote>cadauno</quote>
+                  <quote>cada uno</quote>
                </cit>
                <cit type="trans">
                   <quote>todo</quote>
@@ -31975,7 +31975,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>derechosdeconsumo</quote>
+                  <quote>derechos de consumo</quote>
                </cit>
             </sense>
          </entry>
@@ -31986,7 +31986,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>derechosdeconsumo</quote>
+                  <quote>derechos de consumo</quote>
                </cit>
             </sense>
          </entry>
@@ -32723,7 +32723,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>enamorarsede</quote>
+                  <quote>enamorarse de</quote>
                </cit>
             </sense>
          </entry>
@@ -35589,12 +35589,12 @@
          </entry>
          <entry>
             <form>
-               <orth>fuel</orth>
+               <orth>fuel tank</orth>
                <pron>fjuːəltæŋk</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>depósitodegasolina</quote>
+                  <quote>depósito de gasolina</quote>
                </cit>
             </sense>
          </entry>
@@ -36034,12 +36034,12 @@
          </entry>
          <entry>
             <form>
-               <orth>gas</orth>
+               <orth>gas tank</orth>
                <pron>gəztæŋk</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>depósitodegasolina</quote>
+                  <quote>depósito de gasolina</quote>
                </cit>
             </sense>
          </entry>
@@ -36215,13 +36215,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deveras</quote>
+                  <quote>de veras</quote>
                </cit>
                <cit type="trans">
                   <quote>enefecto</quote>
                </cit>
                <cit type="trans">
-                  <quote>enrealidad</quote>
+                  <quote>en realidad</quote>
                </cit>
                <cit type="trans">
                   <quote>verdaderamente</quote>
@@ -40258,7 +40258,7 @@
             </sense>
             <sense n="3">
                <cit type="trans">
-                  <quote>atítulode</quote>
+                  <quote>a título de</quote>
                </cit>
                </sense>
          </entry>
@@ -40628,7 +40628,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>desentendersede</quote>
+                  <quote>desentenderse de</quote>
                </cit>
             </sense>
          </entry>
@@ -40891,7 +40891,7 @@
                   <quote>a</quote>
                </cit>
                <cit type="trans">
-                  <quote>dentrode</quote>
+                  <quote>dentro de</quote>
                </cit>
                <cit type="trans">
                   <quote>en</quote>
@@ -41061,13 +41061,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deveras</quote>
+                  <quote>de veras</quote>
                </cit>
                <cit type="trans">
                   <quote>enefecto</quote>
                </cit>
                <cit type="trans">
-                  <quote>enrealidad</quote>
+                  <quote>en realidad</quote>
                </cit>
                <cit type="trans">
                   <quote>verdaderamente</quote>
@@ -41682,7 +41682,7 @@
                   <quote>a</quote>
                </cit>
                <cit type="trans">
-                  <quote>dentrode</quote>
+                  <quote>dentro de</quote>
                </cit>
                <cit type="trans">
                   <quote>en</quote>
@@ -42173,7 +42173,7 @@
                   <quote>a</quote>
                </cit>
                <cit type="trans">
-                  <quote>dentrode</quote>
+                  <quote>dentro de</quote>
                </cit>
                <cit type="trans">
                   <quote>en</quote>
@@ -42495,7 +42495,7 @@
                   <quote>antes</quote>
                </cit>
                <cit type="trans">
-                  <quote>delantede</quote>
+                  <quote>delante de</quote>
                </cit>
             </sense>
          </entry>
@@ -42506,7 +42506,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deningunamanera</quote>
+                  <quote>de ninguna manera</quote>
                </cit>
             </sense>
          </entry>
@@ -42570,12 +42570,12 @@
          </entry>
          <entry>
             <form>
-               <orth>in</orth>
+               <orth>in the daytime</orth>
                <pron>inðdeitaim</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>dedia</quote>
+                  <quote>de día</quote>
                </cit>
             </sense>
          </entry>
@@ -42677,7 +42677,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>dehierro</quote>
+                  <quote>de hierro</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -42698,18 +42698,18 @@
          </entry>
          <entry>
             <form>
-               <orth>ironing</orth>
+               <orth>ironing board</orth>
                <pron>aiərəniŋbɔːd</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>tabladeplanchar</quote>
+                  <quote>tabla de planchar</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>iron</orth>
+               <orth>iron clothes</orth>
                <pron>aiənklouðz</pron>
             </form>
             <sense>
@@ -42720,7 +42720,7 @@
          </entry>
          <entry>
             <form>
-               <orth>iron</orth>
+               <orth>iron wire</orth>
                <pron>aiənwaiər</pron>
             </form>
             <sense>
@@ -42777,7 +42777,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>darpartede</quote>
+                  <quote>dar parte de</quote>
                </cit>
                <cit type="trans">
                   <quote>proclamar</quote>
@@ -43644,7 +43644,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>piernastorcidashaciaafuera</quote>
+                  <quote>piernas torcidas hacia afuera</quote>
                </cit>
             </sense>
          </entry>
@@ -43989,7 +43989,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>desprendimientodetierras</quote>
+                  <quote>desprendimiento de tierras</quote>
                </cit>
             </sense>
             </entry>
@@ -44183,10 +44183,10 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>mofarsede</quote>
+                  <quote>mofarse de</quote>
                </cit>
                <cit type="trans">
-                  <quote>reírsede</quote>
+                  <quote>reírse de</quote>
                </cit>
             </sense>
          </entry>
@@ -44567,7 +44567,7 @@
          </entry>
          <entry>
             <form>
-               <orth>leave</orth>
+               <orth>leave behind</orth>
                <pron>liːvbiːhaind</pron>
             </form>
             <sense>
@@ -44575,18 +44575,18 @@
                   <quote>dejar</quote>
                </cit>
                <cit type="trans">
-                  <quote>dejarenpos</quote>
+                  <quote>dejar en pos</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>leave</orth>
+               <orth>leave out of account</orth>
                <pron>liːvautɔfəkaunt</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>desentendersede</quote>
+                  <quote>desentenderse de</quote>
                </cit>
             </sense>
          </entry>
@@ -46482,7 +46482,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>hacerusode</quote>
+                  <quote>hacer uso de</quote>
                </cit>
                <cit type="trans">
                   <quote>usar</quote>
@@ -47858,7 +47858,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>todaclasede</quote>
+                  <quote>toda clase de</quote>
                </cit>
             </sense>
          </entry>
@@ -49382,7 +49382,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -49406,7 +49406,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -49452,7 +49452,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
          </entry>
@@ -49766,7 +49766,7 @@
                   <quote>luego</quote>
                </cit>
                <cit type="trans">
-                  <quote>másadelante</quote>
+                  <quote>más adelante</quote>
                </cit>
             </sense>
             <sense>
@@ -49796,7 +49796,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>cercade</quote>
+                  <quote>cerca de</quote>
                </cit>
             </sense>
          </entry>
@@ -50152,7 +50152,7 @@
                   <quote>carnet</quote>
                </cit>
                <cit type="trans">
-                  <quote>libritodememoria</quote>
+                  <quote>librito de memoria</quote>
                </cit>
             </sense>
          </entry>
@@ -50255,40 +50255,40 @@
          </entry>
          <entry>
             <form>
-               <orth>not</orth>
+               <orth>not at all</orth>
                <pron>nouteitl</pron>
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>deningunamanera</quote>
+                  <quote>de ninguna manera</quote>
                </cit>
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>deningúnmodo</quote>
+                  <quote>de ningún modo</quote>
                </cit>
                <cit type="trans">
-                  <quote>nimuchomenos</quote>
+                  <quote>ni mucho menos</quote>
                </cit>
                <cit type="trans">
-                  <quote>no...deltodo</quote>
+                  <quote>no...del todo</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>not</orth>
+               <orth>not on any account</orth>
                <pron>noutwʌnæniːəkaunt</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deningunamanera</quote>
+                  <quote>de ninguna manera</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>not</orth>
+               <orth>not well</orth>
                <pron>noutwel</pron>
             </form>
             <sense>
@@ -50417,24 +50417,24 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>decuandoencuando</quote>
+                  <quote>de cuando en cuando</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>no</orth>
+               <orth>no doubt</orth>
                <pron>noudaut</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>sinduda</quote>
+                  <quote>sin duda</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>no</orth>
+               <orth>no longer</orth>
                <pron>noulɔŋgər</pron>
             </form>
             <sense>
@@ -50550,7 +50550,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>denilón</quote>
+                  <quote>de nilón</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -51124,7 +51124,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>todaclasede</quote>
+                  <quote>toda clase de</quote>
                </cit>
             </sense>
          </entry>
@@ -51146,7 +51146,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>demalafama</quote>
+                  <quote>de mala fama</quote>
                </cit>
                <cit type="trans">
                   <quote>malreputado</quote>
@@ -51219,7 +51219,7 @@
             </sense>
             <sense n="3">
                <cit type="trans">
-                  <quote>deacuerdo</quote>
+                  <quote>de acuerdo</quote>
                </cit>
                <cit type="trans">
                   <quote>enorden</quote>
@@ -51395,7 +51395,7 @@
                   <quote>a</quote>
                </cit>
                <cit type="trans">
-                  <quote>dentrode</quote>
+                  <quote>dentro de</quote>
                </cit>
                <cit type="trans">
                   <quote>en</quote>
@@ -51406,7 +51406,7 @@
             </sense>
             <sense n="3">
                <cit type="trans">
-                  <quote>pormediode</quote>
+                  <quote>por medio de</quote>
                </cit>
             </sense>
             <sense n="4">
@@ -51417,7 +51417,7 @@
                   <quote>porlotocantea</quote>
                </cit>
                <cit type="trans">
-                  <quote>respectode</quote>
+                  <quote>respecto de</quote>
                </cit>
             </sense>
             <sense n="5">
@@ -51444,10 +51444,10 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>denuevo</quote>
+                  <quote>de nuevo</quote>
                </cit>
                <cit type="trans">
-                  <quote>otravez</quote>
+                  <quote>otra vez</quote>
                </cit>
             </sense>
          </entry>
@@ -51606,7 +51606,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>conmotivode</quote>
+                  <quote>con motivo de</quote>
                </cit>
             </sense>
          </entry>
@@ -51620,7 +51620,7 @@
                   <quote>bocaarriba</quote>
                </cit>
                <cit type="trans">
-                  <quote>deespaldas</quote>
+                  <quote>de espaldas</quote>
                </cit>
             </sense>
          </entry>
@@ -51631,7 +51631,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>depropósito</quote>
+                  <quote>de propósito</quote>
                </cit>
             </sense>
          </entry>
@@ -51820,7 +51820,7 @@
             </sense>
             <sense>
                <cit type="trans">
-                  <quote>enfrentede</quote>
+                  <quote>en frente de</quote>
                </cit>
             </sense>
          </entry>
@@ -52140,7 +52140,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>fuerade</quote>
+                  <quote>fuera de</quote>
                </cit>
             </sense>
             <sense n="2">
@@ -52164,7 +52164,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>fuerade</quote>
+                  <quote>fuera de</quote>
                </cit>
             </sense>
          </entry>
@@ -52216,7 +52216,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>encimade</quote>
+                  <quote>encima de</quote>
                </cit>
             </sense>
          </entry>
@@ -53710,7 +53710,7 @@
                   <quote>a</quote>
                </cit>
                <cit type="trans">
-                  <quote>dentrode</quote>
+                  <quote>dentro de</quote>
                </cit>
                <cit type="trans">
                   <quote>en</quote>
@@ -54021,12 +54021,12 @@
          </entry>
          <entry>
             <form>
-               <orth>petrol</orth>
+               <orth>petrol tank</orth>
                <pron>pitroultæŋk</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>depósitodegasolina</quote>
+                  <quote>depósito de gasolina</quote>
                </cit>
             </sense>
          </entry>
@@ -56368,7 +56368,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>antesdeque</quote>
+                  <quote>antes de que</quote>
                </cit>
             </sense>
          </entry>
@@ -56592,7 +56592,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>darpartede</quote>
+                  <quote>dar parte de</quote>
                </cit>
                <cit type="trans">
                   <quote>proclamar</quote>
@@ -58349,13 +58349,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deveras</quote>
+                  <quote>de veras</quote>
                </cit>
                <cit type="trans">
                   <quote>enefecto</quote>
                </cit>
                <cit type="trans">
-                  <quote>enrealidad</quote>
+                  <quote>en realidad</quote>
                </cit>
                <cit type="trans">
                   <quote>verdaderamente</quote>
@@ -59167,7 +59167,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deconfianza</quote>
+                  <quote>de confianza</quote>
                </cit>
             </sense>
          </entry>
@@ -59197,10 +59197,10 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>desistirde</quote>
+                  <quote>desistir de</quote>
                </cit>
                <cit type="trans">
-                  <quote>renunciara</quote>
+                  <quote>renunciar a</quote>
                </cit>
             </sense>
          </entry>
@@ -59376,10 +59376,10 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>desistirde</quote>
+                  <quote>desistir de</quote>
                </cit>
                <cit type="trans">
-                  <quote>renunciara</quote>
+                  <quote>renunciar a</quote>
                </cit>
             </sense>
          </entry>
@@ -60943,7 +60943,7 @@
                   <quote>alrededorde</quote>
                </cit>
                <cit type="trans">
-                  <quote>entornode</quote>
+                  <quote>en torno de</quote>
                </cit>
             </sense>
          </entry>
@@ -62235,13 +62235,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>desegundamano</quote>
+                  <quote>de segundamano</quote>
                </cit>
             </sense>
          </entry>
          <entry>
             <form>
-               <orth>second</orth>
+               <orth>second cousin</orth>
                <pron>skoundkʌzn</pron>
             </form>
             <sense>
@@ -62252,12 +62252,12 @@
          </entry>
          <entry>
             <form>
-               <orth>second</orth>
+               <orth>second hand</orth>
                <pron>skoundhænd</pron>
             </form>
             <sense>
                <cit type="trans">
-                  <quote>desegundamano</quote>
+                  <quote>de segundamano</quote>
                </cit>
             </sense>
          </entry>
@@ -63051,7 +63051,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>depocaprofundidad</quote>
+                  <quote>de poca profundidad</quote>
                </cit>
                <cit type="trans">
                   <quote>somero</quote>
@@ -64829,7 +64829,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>departamentodefumar</quote>
+                  <quote>departamento de fumar</quote>
                </cit>
             </sense>
          </entry>
@@ -67385,7 +67385,7 @@
             </sense>
             <sense n="3">
                <cit type="trans">
-                  <quote>declararseenhuelga</quote>
+                  <quote>declararse en huelga</quote>
                </cit>
             </sense>
             <sense n="4">
@@ -67703,7 +67703,7 @@
                   <quote>luego</quote>
                </cit>
                <cit type="trans">
-                  <quote>másadelante</quote>
+                  <quote>más adelante</quote>
                </cit>
             </sense>
          </entry>
@@ -67824,7 +67824,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>atítulode</quote>
+                  <quote>a título de</quote>
                </cit>
                <cit type="trans">
                   <quote>como</quote>
@@ -67876,13 +67876,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>degolpe</quote>
+                  <quote>de golpe</quote>
                </cit>
                <cit type="trans">
-                  <quote>derepente</quote>
+                  <quote>de repente</quote>
                </cit>
                <cit type="trans">
-                  <quote>desopetón</quote>
+                  <quote>de sopetón</quote>
                </cit>
             </sense>
          </entry>
@@ -68188,7 +68188,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>depocaprofundidad</quote>
+                  <quote>de poca profundidad</quote>
                </cit>
                <cit type="trans">
                   <quote>somero</quote>
@@ -69152,7 +69152,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>cuidarsede</quote>
+                  <quote>cuidarse de</quote>
                </cit>
             </sense>
          </entry>
@@ -71027,7 +71027,7 @@
             </sense>
             <sense n="3">
                <cit type="trans">
-                  <quote>pormediode</quote>
+                  <quote>por medio de</quote>
                </cit>
             </sense>
             <sense n="4">
@@ -71037,7 +71037,7 @@
             </sense>
             <sense n="5">
                <cit type="trans">
-                  <quote>alolargode</quote>
+                  <quote>a lo largo de</quote>
                </cit>
                <cit type="trans">
                   <quote>por</quote>
@@ -71545,7 +71545,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>dedodepie</quote>
+                  <quote>dedo de pie</quote>
                </cit>
             </sense>
          </entry>
@@ -71917,7 +71917,7 @@
                   <quote>alrededorde</quote>
                </cit>
                <cit type="trans">
-                  <quote>entornode</quote>
+                  <quote>en torno de</quote>
                </cit>
             </sense>
          </entry>
@@ -72546,13 +72546,13 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deveras</quote>
+                  <quote>de veras</quote>
                </cit>
                <cit type="trans">
                   <quote>enefecto</quote>
                </cit>
                <cit type="trans">
-                  <quote>enrealidad</quote>
+                  <quote>en realidad</quote>
                </cit>
                <cit type="trans">
                   <quote>verdaderamente</quote>
@@ -72596,7 +72596,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>deconfianza</quote>
+                  <quote>de confianza</quote>
                </cit>
             </sense>
          </entry>
@@ -72833,7 +72833,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>piernastorcidashaciaafuera</quote>
+                  <quote>piernas torcidas hacia afuera</quote>
                </cit>
             </sense>
          </entry>
@@ -73208,7 +73208,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>debajode</quote>
+                  <quote>debajo de</quote>
                </cit>
             </sense>
          </entry>
@@ -73249,7 +73249,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>debajode</quote>
+                  <quote>debajo de</quote>
                </cit>
             </sense>
             </entry>
@@ -73326,7 +73326,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>encargarsede</quote>
+                  <quote>encargarse de</quote>
                </cit>
                <cit type="trans">
                   <quote>emprender</quote>
@@ -73348,7 +73348,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>sinduda</quote>
+                  <quote>sin duda</quote>
                </cit>
             </sense>
          </entry>
@@ -73611,7 +73611,7 @@
                   <quote>porlotocantea</quote>
                </cit>
                <cit type="trans">
-                  <quote>respectode</quote>
+                  <quote>respecto de</quote>
                </cit>
             </sense>
             <sense n="3">
@@ -73782,7 +73782,7 @@
             </form>
             <sense n="1">
                <cit type="trans">
-                  <quote>hacerusode</quote>
+                  <quote>hacer uso de</quote>
                </cit>
                <cit type="trans">
                   <quote>usar</quote>
@@ -74813,10 +74813,10 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>desistirde</quote>
+                  <quote>desistir de</quote>
                </cit>
                <cit type="trans">
-                  <quote>renunciara</quote>
+                  <quote>renunciar a</quote>
                </cit>
             </sense>
          </entry>
@@ -74897,7 +74897,7 @@
          </entry>
          <entry>
             <form>
-               <orth>wander</orth>
+               <orth>wander from one's subject</orth>
                <pron>wɔndərfrɔmwʌnzsʌbdʒikt</pron>
             </form>
             <sense>
@@ -75370,7 +75370,7 @@
          </entry>
          <entry>
             <form>
-               <orth>wear</orth>
+               <orth>wear away</orth>
                <pron>wɛərɔːwei</pron>
             </form>
             <sense>
@@ -75381,7 +75381,7 @@
          </entry>
          <entry>
             <form>
-               <orth>wear</orth>
+               <orth>wear off</orth>
                <pron>wɛərɔf</pron>
             </form>
             <sense>
@@ -75392,7 +75392,7 @@
          </entry>
          <entry>
             <form>
-               <orth>wear</orth>
+               <orth>wear out</orth>
                <pron>wɛəraut</pron>
             </form>
             <sense n="1">
@@ -75628,7 +75628,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>atítulode</quote>
+                  <quote>a título de</quote>
                </cit>
                <cit type="trans">
                   <quote>como</quote>
@@ -76149,7 +76149,7 @@
             </sense>
             <sense n="2">
                <cit type="trans">
-                  <quote>pormediode</quote>
+                  <quote>por medio de</quote>
                </cit>
             </sense>
          </entry>
@@ -76163,7 +76163,7 @@
                   <quote>a</quote>
                </cit>
                <cit type="trans">
-                  <quote>dentrode</quote>
+                  <quote>dentro de</quote>
                </cit>
                <cit type="trans">
                   <quote>en</quote>
@@ -76339,7 +76339,7 @@
             </form>
             <sense>
                <cit type="trans">
-                  <quote>demadera</quote>
+                  <quote>de madera</quote>
                </cit>
             </sense>
          </entry>
@@ -76764,7 +76764,7 @@
          </entry>
          <entry>
             <form>
-               <orth>write</orth>
+               <orth>write down</orth>
                <pron>raitdaun</pron>
             </form>
             <sense>


### PR DESCRIPTION
Separate a bunch of multi-word phrases, recover some deleted words from multiword lemmas in `eng-spa`.  Something really must have gotten garbled on the initial import--I'm wondering if it makes more sense to go back to the original from which the TEI sources were derived...