### PR TITLE
eng-spa: crash: fix spelling of 'chocar'

### DIFF
--- a/eng-spa/eng-spa.tei
+++ b/eng-spa/eng-spa.tei
@@ -22450,7 +22450,7 @@
                   <quote>abordar</quote>
                </cit>
                <cit type="trans">
-                  <quote>chocarkun</quote>
+                  <quote>chocar</quote>
                </cit>
             </sense>
          </entry>
@@ -25462,7 +25462,7 @@
                   <quote>abordar</quote>
                </cit>
                <cit type="trans">
-                  <quote>chocarkun</quote>
+                  <quote>chocar</quote>
                </cit>
             </sense>
          </entry>


### PR DESCRIPTION
'chocarkun' doesn't exist in Spanish.  But 'chocar' does exist and means 'to crash'.  'crash' as a noun would be translated as 'choque'.

I'm not sure if we should include the verb, the noun, or both.

Also, abordar as a translation of crash is not precise.  Abordar means 'board', as in what the pirates do with ships.